### PR TITLE
Don't store inputEvent statefully

### DIFF
--- a/apps/RunSkeleton.hs
+++ b/apps/RunSkeleton.hs
@@ -13,7 +13,10 @@ inputChanDummyWorker chan =
   let go :: Int -> IO ()
       go k = do
         CC.threadDelay 500000
-        writeChan chan (GuiInputEvent k)
+        writeChan chan $ case k `mod` 5 of
+          0 -> GuiInputEvent_Clear
+          2 -> GuiInputEvent_Squawk
+          _ -> GuiInputEvent_Other k
         go (k + 1)
   in go 0
 


### PR DESCRIPTION
To make `inputEvent` stateless without also being useless (since the only thing we were doing with it was capturing it on commit), I had to invent a few things for it to do.  What this does now is:

1. The status label counts the total number of times `inputEvent` has occurred since the creation of the label.
2. On timesteps that are a multiple of 5, the textbox will clear itself
3. On timesteps that are 2 greater than a multiple of 5, the main widget will output `"Squawk!"` on stdout

In the first case, we've moved the `holdDyn`-style statefulness (in the form of `count`) down into the label widget.  Whether this is desirable or not depends on application architecture, and requires an additional constraint on the monad, `MonadHold`, so we can control whether widgets are allowed to do this.  In the case of GUI widgets, it usually doesn't make sense to withhold `MonadHold` from widgets, since they can smuggle statefulness in through `PerformEvent` and through the GUI widgets themselves.  However, in other contexts, it can be useful to have a function that manipulates FRP values while knowing that the function itself is totally stateless.

In the second case, we're not keeping any of our own state in the widget, just using the occurrence to immediately clear the textbox (though the textbox itself is local state).

In the third case, we're actually stateless: we just perform an action when the event occurs, and then forget about it.  (Although, if you wanted to get really philosophical, you could consider it to be a modification of the state of `stdout`, or even of the state of the universe, much like IO is really `State# RealWorld -> (# State# RealWorld, a #)` under the hood.  Ultimately `Event`s are only significant insofar as they either affect the state of the dataflow graph (i.e. terminate in a `hold`, `holdDyn`, or similar) or cause an occurrence of some `Event` to exit the dataflow graph (i.e. terminate in the real world).  Indeed, this is reflected in the garbage collection approach Reflex takes, in which those two things are the only roots from which `Event`s are reachable via strong references.)